### PR TITLE
fix: update XPath for category selection and schedule date button in …

### DIFF
--- a/yt_upload/components/_YTDetailsComponent.py
+++ b/yt_upload/components/_YTDetailsComponent.py
@@ -82,7 +82,7 @@ class YTDetailsComponent:
     license_item_by_index_xpath = "//*[@id='text-item-{index}']"
     
     # components to set category
-    category_show_paper_list_button_xpath = "//html/body/ytcp-uploads-dialog/tp-yt-paper-dialog/div/ytcp-animatable[1]/ytcp-ve/ytcp-video-metadata-editor/div/ytcp-video-metadata-editor-advanced/div[12]/div[3]/ytcp-form-select/ytcp-select/ytcp-text-dropdown-trigger/ytcp-dropdown-trigger/div/div[3]/tp-yt-iron-icon"
+    category_show_paper_list_button_xpath = "//html/body/ytcp-uploads-dialog/tp-yt-paper-dialog/div/ytcp-animatable[1]/ytcp-ve/ytcp-video-metadata-editor/div/ytcp-video-metadata-editor-advanced/div[12]/div[3]/ytcp-form-select/ytcp-select/ytcp-text-dropdown-trigger/ytcp-dropdown-trigger/div/div[3]"
     category_items_xpath = "//*[@id='dialog']"
     category_item_xpath = "//ytcp-ve"
     category_item_title_xpath = "//tp-yt-paper-item-body/div/div/div/yt-formatted-string"

--- a/yt_upload/components/_YTVisibilityComponent.py
+++ b/yt_upload/components/_YTVisibilityComponent.py
@@ -9,7 +9,7 @@ class YTVisibilityComponent:
     public_radio_button_xpath = "//tp-yt-paper-radio-button[@name='PUBLIC']//div[@id='radioContainer']"
     
     schedule_show_button_xpath = "//div[@id='second-container']//ytcp-icon-button"
-    schedule_date_button_xpath = "//ytcp-text-dropdown-trigger[@id='datepicker-trigger']//tp-yt-iron-icon"
+    schedule_date_button_xpath = "//ytcp-text-dropdown-trigger[@id='datepicker-trigger']"
     schedule_date_input_xpath = "//ytcp-date-picker//tp-yt-paper-dialog//form//input"
     schedule_time_input_xpath = "//form//tp-yt-paper-input//input"
     


### PR DESCRIPTION
This pull request updates the XPath selectors in two component classes to improve the reliability of UI element targeting. The changes remove unnecessary specificity from the XPath expressions, likely to make them less brittle and more robust to minor changes in the DOM structure.

**Component selector updates:**

* In `YTDetailsComponent`, the `category_show_paper_list_button_xpath` selector was simplified by removing the trailing `/tp-yt-iron-icon`, making the XPath less dependent on a specific child element.
* In `YTVisibilityComponent`, the `schedule_date_button_xpath` selector was similarly simplified by removing the `/tp-yt-iron-icon` suffix, targeting the parent element directly.